### PR TITLE
fix: add autopep8 to dependencies list

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ let
     ps.pytest
     ps.typing-extensions
     ps.mypy
+    ps.autopep8
   ]);
 in mkShell {
   packages = [


### PR DESCRIPTION
Signed-off-by: isubasinghe <i.subasinghe@unsw.edu.au>